### PR TITLE
Updated Dockerfile to install chrome and fixed jar

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:23-jre-noble
 
+RUN apt-get update && apt-get install chromium-browser -y && apt-get install chromium-chromedriver -y
+
 ENV JMB_VERSION 0.4.3
 
 #No downloadable example config since 0.2.10


### PR DESCRIPTION
Updated Dockerfile to install chromium for POToken fix and included latest JAR. 

Will need to update config file download, but will wait until latest release from upstream. 